### PR TITLE
Add a health check for Lifecycle start

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -53,6 +53,15 @@
     </dependency>
 
     <dependency>
+      <groupId>com.opentable.components</groupId>
+      <artifactId>otj-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.codahale.metrics</groupId>
+      <artifactId>metrics-healthchecks</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.skife.config</groupId>
       <artifactId>config-magic</artifactId>
     </dependency>


### PR DESCRIPTION
This should prevent Singularity from treating a task as healthy until it has STARTed.
