### PR TITLE
Codahale -> Dropwizard updates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.opentable</groupId>
     <artifactId>otj-parent</artifactId>
-    <version>47</version>
+    <version>49</version>
   </parent>
 
   <scm>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -62,7 +62,7 @@
       <artifactId>otj-metrics</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.codahale.metrics</groupId>
+      <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-healthchecks</artifactId>
     </dependency>
 

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -126,6 +126,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-healthchecks</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.opentable.components</groupId>
       <artifactId>otj-server</artifactId>
       <scope>test</scope>

--- a/templates/src/main/java/com/opentable/server/templates/BasicRestHttpServerTemplateModule.java
+++ b/templates/src/main/java/com/opentable/server/templates/BasicRestHttpServerTemplateModule.java
@@ -15,8 +15,10 @@
  */
 package com.opentable.server.templates;
 
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
 import com.google.inject.AbstractModule;
-import com.palominolabs.metrics.guice.InstrumentationModule;
+import com.palominolabs.metrics.guice.MetricsInstrumentationModule;
 
 import com.opentable.config.Config;
 import com.opentable.conservedheaders.ClientConservedHeadersFeature;
@@ -67,7 +69,12 @@ public class BasicRestHttpServerTemplateModule extends AbstractModule
     {
         install (new ThreadDelegatedScopeModule());
 
-        install (new InstrumentationModule());
+        // TODO Perhaps place these into a separate module?
+        final MetricRegistry metricRegistry = new MetricRegistry();
+        bind(MetricRegistry.class).toInstance(metricRegistry);
+        install (new MetricsInstrumentationModule(metricRegistry));
+        bind(HealthCheckRegistry.class).toInstance(new HealthCheckRegistry());
+
         install (new JmxServerModule());
         install (new JolokiaModule());
 


### PR DESCRIPTION
When updating Guava to a later version, we discovered that there were
now conflicting classes for various Codahale metrics libraries.  This
led us to discover that the project started out as one of Coda's
personal projects; it used class namespace `com.codahale.metrics`.  He
was working at Yammer at the time, and the project became sufficiently
important for them to change its packaging to be associated with Yammer.
When they did this, they _changed_ the class namespace to
`com.yammer.metrics`.  Later, the project became sufficiently valuable
to the community that they open-sourced it.  On doing this, though, they
_changed the class namespace _back__ to `com.codahale.metrics` despite
the fact that the artifact `groupId` changed yet again to
`io.dropwizard.metrics`.  (wtf!)  We want only the modern Dropwizard
artifacts.

[See more here.](https://groups.google.com/d/msg/dropwizard-user/1usH7frpnZE/RSQUsOBFMsoJ)
