### PR TITLE
Allow customization of Jetty QueuedThreadPool

### DIFF
--- a/src/test/java/com/opentable/server/BasicTest.java
+++ b/src/test/java/com/opentable/server/BasicTest.java
@@ -9,12 +9,14 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.io.IOUtils;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -22,9 +24,15 @@ import org.springframework.test.context.junit4.SpringRunner;
 @ContextConfiguration(classes = {
     TestServer.class
 })
+@TestPropertySource(properties= {
+    "ot.httpserver.max-threads=13",
+})
 public class BasicTest {
     @Inject
     LoopbackRequest request;
+
+    @Inject
+    EmbeddedJetty ej;
 
     @Test
     public void testHello() throws IOException {
@@ -45,6 +53,13 @@ public class BasicTest {
     @Test
     public void testStatic_png() throws IOException {
         testStatic("static/test.png", "image/png");
+    }
+
+    @Test
+    public void testPoolCustomizations() throws Exception {
+        QueuedThreadPool qtp = ej.getThreadPool();
+        assertEquals(13, qtp.getMinThreads());
+        assertEquals(13, qtp.getMaxThreads());
     }
 
     private void testStatic(final String path, final String expectedContentType) throws IOException {


### PR DESCRIPTION
This is a workaround for https://github.com/spring-projects/spring-boot/issues/5314 that restores compatibility with the old Guice `otj-httpserver`

Depends on #15
