### PR TITLE
OTApplication: allow optional configuration of SpringApplicationBuilder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.opentable.components</groupId>
   <artifactId>otj-server</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:git://github.com/opentable/${project.artifactId}.git</connection>

--- a/src/main/java/com/opentable/server/OTApplication.java
+++ b/src/main/java/com/opentable/server/OTApplication.java
@@ -1,11 +1,43 @@
 package com.opentable.server;
 
+import java.util.function.Consumer;
+
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 
+/**
+ * OpenTable specific Spring Boot style application runner.
+ * Sets up logging and other OT specific customizations.
+ *
+ * Note that this API only accepts {@code Class<?>} arguments
+ * rather than generic {@code Object} -- this is a style choice,
+ * we prefer to write explicit classes rather than relying on instances.
+ * This can change down the road if needed.
+ */
 public class OTApplication {
+    /**
+     * Construct and run a {@link SpringApplication} with the default settings for
+     * {code otj-} OpenTable Spring Boot based applications.
+     * @param applicationClass the main class to boot.  Should be a Spring configuration class.
+     * @param args the application arguments from main()
+     * @return the configured application context
+     */
     public static ConfigurableApplicationContext run(Class<?> applicationClass, String[] args) {
+        return run(applicationClass, args, b -> {});
+    }
+
+    /**
+     * Construct and run a {@link SpringApplication} with custom settings for
+     * {code otj-} OpenTable Spring Boot based applications.
+     * @param applicationClass the main class to boot.  Should be a Spring configuration class.
+     * @param args the application arguments from main()
+     * @return the configured application context
+     */
+    public static ConfigurableApplicationContext run(Class<?> applicationClass, String[] args, Consumer<SpringApplicationBuilder> customizer) {
         System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
-        return SpringApplication.run(applicationClass, args);
+        final SpringApplicationBuilder builder = new SpringApplicationBuilder(applicationClass);
+        customizer.accept(builder);
+        return builder.run(args);
     }
 }


### PR DESCRIPTION
Example usage:
```java
/**
 * Start a local Chat v2 server with development credentials
 * and a throwaway database.
 */
@Import(ChatDatabase.class)
public class ChatDevServerMain extends ChatMain {
    public static void main(final String[] args) {
        OTApplication.run(ChatDevServerMain.class, args, b -> {
            b.properties(ImmutableMap.of(
                    "ot.http.bind-port", "8080"
            ));
        });
    }
}
```
