### PR TITLE
Configure RESTEasy to send back charset utf-8 if you don't specify

### DIFF
--- a/src/main/java/com/opentable/server/ResteasyAutoConfiguration.java
+++ b/src/main/java/com/opentable/server/ResteasyAutoConfiguration.java
@@ -1,13 +1,12 @@
 package com.opentable.server;
 
-import java.util.Collections;
-
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.ws.rs.ext.RuntimeDelegate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.google.common.collect.ImmutableMap;
 
 import org.jboss.resteasy.core.Dispatcher;
 import org.jboss.resteasy.plugins.server.servlet.Filter30Dispatcher;
@@ -40,7 +39,10 @@ public class ResteasyAutoConfiguration {
     public FilterRegistrationBean resteasyServletRegistration() {
         FilterRegistrationBean registrationBean = new FilterRegistrationBean(new Filter30Dispatcher());
         registrationBean.addUrlPatterns("/*");
-        registrationBean.setInitParameters(Collections.singletonMap("resteasy.servlet.mapping.prefix", "/")); // set prefix here
+        registrationBean.setInitParameters(
+                ImmutableMap.of(
+                        "resteasy.servlet.mapping.prefix", "/", // set prefix here
+                        "resteasy.add.charset", "true")); // any text/* response without encoding info gets UTF-8
         return registrationBean;
     }
 


### PR DESCRIPTION
fixes
```
2017-07-12T19:47:25.419Z INFO  <> [main] o.jboss.resteasy.resteasy_jaxrs.i18n - RESTEASY002227: MediaType text/plain on getGreeting() lacks charset. Consider setting charset or turning on context parameter resteasy.add.charset
2017-07-12T19:47:25.419Z INFO  <> [main] o.jboss.resteasy.resteasy_jaxrs.i18n - RESTEASY002227: MediaType text/plain on getDebug() lacks charset. Consider setting charset or turning on context parameter resteasy.add.charset
```