### PR TITLE
add config with default values to allow a sleep before jetty shutdown

### DIFF
--- a/src/main/java/com/opentable/server/EmbeddedJettyBase.java
+++ b/src/main/java/com/opentable/server/EmbeddedJettyBase.java
@@ -114,7 +114,7 @@ public abstract class EmbeddedJettyBase {
     @Value("${ot.httpserver.sleep-before-shutdown:false}")
     boolean shouldSleepBeforeShutdown;
 
-    @Value("${ot.httpserver.sleep-duration-millis-before-shutdown:0}")
+    @Value("${ot.httpserver.sleep-duration-millis-before-shutdown:5000}")
     long sleepDurationMillisBeforeShutdown;
 
     /**

--- a/src/main/java/com/opentable/server/EmbeddedJettyBase.java
+++ b/src/main/java/com/opentable/server/EmbeddedJettyBase.java
@@ -29,7 +29,6 @@ import java.util.function.IntSupplier;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.management.MBeanServer;
-import javax.validation.Valid;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/opentable/server/EmbeddedJettyBase.java
+++ b/src/main/java/com/opentable/server/EmbeddedJettyBase.java
@@ -110,12 +110,12 @@ public abstract class EmbeddedJettyBase {
     @Value("${ot.httpserver.ssl-allowed-deprecated-ciphers:}")
     List<String> allowedDeprecatedCiphers;
 
-    // the following two values (shouldSleepBeforeShutdown, sleepDurationMillisBeforeShutdown) help an application control whether they want a pause before jetty shutdown to ensure that the discovery unannounce has propagated to all clients requesting the application
+    // the following two values (shouldSleepBeforeShutdown, sleepDurationBeforeShutdown) help an application control whether they want a pause before jetty shutdown to ensure that the discovery unannounce has propagated to all clients requesting the application
     @Value("${ot.httpserver.sleep-before-shutdown:false}")
     boolean shouldSleepBeforeShutdown;
 
-    @Value("${ot.httpserver.sleep-duration-millis-before-shutdown:5000}")
-    long sleepDurationMillisBeforeShutdown;
+    @Value("${ot.httpserver.sleep-duration-before-shutdown:PT5s}")
+    Duration sleepDurationBeforeShutdown;
 
     /**
      * In the case that we bind to port 0, we'll get back a port from the OS.
@@ -313,12 +313,14 @@ public abstract class EmbeddedJettyBase {
         LOG.info("Early shutdown of Jetty connectors on {}", container);
         if (container != null) {
             if(shouldSleepBeforeShutdown) {
-                LOG.info("Application config requesting sleep for "+sleepDurationMillisBeforeShutdown+" ms before jetty shutdown");
+                long sleepDurationMillisBeforeShutdown = sleepDurationBeforeShutdown.toMillis();
+                LOG.info("Application config requesting sleep for {} ms before Jetty shutdown", sleepDurationMillisBeforeShutdown);
                 try {
-                    LOG.info("Sleeping for "+sleepDurationMillisBeforeShutdown+" ms before jetty shutdown");
+                    LOG.info("Sleeping for {} ms before jetty shutdown", sleepDurationMillisBeforeShutdown);
                     Thread.sleep(sleepDurationMillisBeforeShutdown);
                 } catch (InterruptedException e) {
-                    LOG.error("Failed to sleep before shutdown "+e.getMessage() );
+                    LOG.error("Failed to sleep before shutdown {}", e);
+                    Thread.currentThread().interrupt();
                 }
             }
             container.stop();

--- a/src/main/java/com/opentable/server/EmbeddedJettyBase.java
+++ b/src/main/java/com/opentable/server/EmbeddedJettyBase.java
@@ -315,18 +315,22 @@ public abstract class EmbeddedJettyBase {
             if(shouldSleepBeforeShutdown) {
                 long sleepDurationMillisBeforeShutdown = sleepDurationBeforeShutdown.toMillis();
                 LOG.info("Application config requesting sleep for {} ms before Jetty shutdown", sleepDurationMillisBeforeShutdown);
-                try {
-                    LOG.info("Sleeping for {} ms before jetty shutdown", sleepDurationMillisBeforeShutdown);
-                    Thread.sleep(sleepDurationMillisBeforeShutdown);
-                } catch (InterruptedException e) {
-                    LOG.error("Failed to sleep before shutdown {}", e);
-                    Thread.currentThread().interrupt();
-                }
+                sleepBeforeJettyShutdown(sleepDurationMillisBeforeShutdown);
             }
             container.stop();
             LOG.info("Jetty is stopped.");
         } else {
             LOG.warn("Never got a Jetty?");
+        }
+    }
+
+    private void sleepBeforeJettyShutdown(long sleepDurationMillisBeforeShutdown) {
+        try {
+            LOG.info("Sleeping for {} ms before jetty shutdown", sleepDurationMillisBeforeShutdown);
+            Thread.sleep(sleepDurationMillisBeforeShutdown);
+        } catch (InterruptedException e) {
+            LOG.error("Failed to sleep before shutdown {}", e);
+            Thread.currentThread().interrupt();
         }
     }
 


### PR DESCRIPTION
to ensure that the unannounce caused by a service shutdown propagates fully through our network this PR adds configuration support to control whether to sleep before jetty shutdown to give time to the unannounce to propagate. it also adds configuration to control the duration of the sleep