### PR TITLE
Fix Reactive.

### DIFF
--- a/otj-server-jaxrs/src/main/java/com/opentable/server/RestReactiveHttpServer.java
+++ b/otj-server-jaxrs/src/main/java/com/opentable/server/RestReactiveHttpServer.java
@@ -31,5 +31,6 @@ import org.springframework.context.annotation.Import;
     EmbeddedReactiveJetty.class,
     JAXRSHttpServerCommonConfiguration.class
 })
+@NonWebSetup
 public @interface RestReactiveHttpServer {
 }


### PR DESCRIPTION
We are still not pulling in @CoreHttpServer but a subset, because it's not clear to me the filter stuff is useful, and that annotation is dependent on embedded jetty
@scottjohnson Please confirm this works