### PR TITLE
 Fix EmbeddedReactiveJetty config for latest parent

### DIFF
--- a/otj-server-core/src/main/java/com/opentable/server/CoreHttpServerCommon.java
+++ b/otj-server-core/src/main/java/com/opentable/server/CoreHttpServerCommon.java
@@ -34,6 +34,8 @@ import com.opentable.components.filterorder.FilterOrderResolverConfiguration;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Import({
+    // Set up dependencies of EmbeddedJettyBase
+    EmbeddedJettyConfiguration.class,
     // Embedded jetty
     EmbeddedJetty.class,
     // Filter for transfer core info to MDC

--- a/otj-server-core/src/main/java/com/opentable/server/EmbeddedJetty.java
+++ b/otj-server-core/src/main/java/com/opentable/server/EmbeddedJetty.java
@@ -35,7 +35,6 @@ import org.springframework.core.env.PropertyResolver;
 
 import com.opentable.components.filterorder.FilterOrderResolver;
 import com.opentable.logging.jetty.JsonRequestLogConfig;
-import com.opentable.spring.SpecializedConfigFactory;
 
 /**
  * Configure an embedded {@code Jetty 9} HTTP(S) server, and tie it into the Spring Boot lifecycle.
@@ -57,11 +56,6 @@ public class EmbeddedJetty extends EmbeddedJettyBase {
 
     @Inject
     Optional<Collection<Consumer<WebAppContext>>> webAppContextCustomizers;
-
-    @Bean
-    public SpecializedConfigFactory<ServerConnectorConfig> connectorConfigs(PropertyResolver pr) {
-        return SpecializedConfigFactory.create(pr, ServerConnectorConfig.class, "ot.httpserver.connector.${name}");
-    }
 
     /**
      * @param filterOrderResolver The filter order resolver is injected here since this method is the one in which we

--- a/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyConfiguration.java
+++ b/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyConfiguration.java
@@ -1,0 +1,19 @@
+package com.opentable.server;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.PropertyResolver;
+
+import com.opentable.spring.SpecializedConfigFactory;
+
+/**
+ * Provide beans required to construct implementations of {@link EmbeddedJettyBase}.
+ */
+@Configuration
+public class EmbeddedJettyConfiguration {
+
+    @Bean
+    public SpecializedConfigFactory<ServerConnectorConfig> connectorConfigs(PropertyResolver pr) {
+        return SpecializedConfigFactory.create(pr, ServerConnectorConfig.class, "ot.httpserver.connector.${name}");
+    }
+}

--- a/otj-server-jaxrs/src/main/java/com/opentable/server/RestReactiveHttpServer.java
+++ b/otj-server-jaxrs/src/main/java/com/opentable/server/RestReactiveHttpServer.java
@@ -21,6 +21,8 @@ import java.lang.annotation.Target;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import com.opentable.components.filterorder.FilterOrderResolverConfiguration;
+
 /**
  * REST Reactive HTTP Server.
  */
@@ -28,8 +30,16 @@ import org.springframework.context.annotation.Import;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Import({
+    EmbeddedJettyConfiguration.class,
     EmbeddedReactiveJetty.class,
-    JAXRSHttpServerCommonConfiguration.class
+    JAXRSHttpServerCommonConfiguration.class,
+    // Filter for transfer core info to MDC
+    BackendInfoFilterConfiguration.class,
+    // Support static resources
+    StaticResourceConfiguration.class,
+    // Filter order
+    FilterOrderResolverConfiguration.class,
 })
+@NonWebSetup
 public @interface RestReactiveHttpServer {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.opentable</groupId>
         <artifactId>otj-parent-spring</artifactId>
-        <version>184</version>
+        <version>187</version>
     </parent>
 
 


### PR DESCRIPTION
Moves the `SpecializedConfigFactory` to a common location for both `EmbeddedJetty` and `EmbeddedReactiveJetty`, and missing annotations to the latter's configuration file.

Also bumps the paren pom to @mikebell90's latest release.