### PR TITLE
Java11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 otj-server
 ==========
 
+3.0.8
+-----
+* Added configuration parameter `ot.httpserver.ssl-excluded-protocols`  
+To address Java 11's problematic implementation of TLS 1.3
+
 3.0.7
 -----
 * Split Reactive Server in to its own top-level server component

--- a/otj-server-core/pom.xml
+++ b/otj-server-core/pom.xml
@@ -138,7 +138,6 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
+++ b/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
@@ -19,7 +19,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -269,12 +268,8 @@ public abstract class EmbeddedJettyBase {
 
         if (ssl != null) {
             if (!CollectionUtils.isEmpty(excludedProtocols)) {
-                LOG.warn("***************************************************************************************");
-                LOG.warn("Excluding following protocols");
-                excludedProtocols.forEach(protocol ->
-                        LOG.warn("    * {}", protocol)
-                );
-                LOG.warn("***************************************************************************************");
+                LOG.warn("Excluding following protocols:");
+                excludedProtocols.forEach(protocol -> LOG.info("Disabling {}", protocol));
                 ssl.setExcludeProtocols(excludedProtocols.toArray(new String[0]));
             }
 

--- a/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
+++ b/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
@@ -269,7 +269,7 @@ public abstract class EmbeddedJettyBase {
         if (ssl != null) {
             if (!CollectionUtils.isEmpty(excludedProtocols)) {
                 LOG.warn("Excluding following protocols:");
-                excludedProtocols.forEach(protocol -> LOG.info("Disabling {}", protocol));
+                excludedProtocols.forEach(protocol -> LOG.warn("Disabling {}", protocol));
                 ssl.setExcludeProtocols(excludedProtocols.toArray(new String[0]));
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.opentable</groupId>
         <artifactId>otj-parent-spring</artifactId>
-        <version>187</version>
+        <version>190</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
         <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
 
-        <project.build.targetJdk>11</project.build.targetJdk>
         <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
         <dep.plugin.spotbugs.version>3.1.11</dep.plugin.spotbugs.version>
         <dep.otj-filterorder.version>0.0.5</dep.otj-filterorder.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,38 +40,37 @@
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
         <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
 
-            <project.build.targetJdk>11</project.build.targetJdk>
-            <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
-            <dep.spotbugs.version>3.1.11</dep.spotbugs.version>
-            <dep.plugin.spotbugs.version>3.1.11</dep.plugin.spotbugs.version>
-        </properties>
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.shared</groupId>
-                            <artifactId>maven-dependency-analyzer</artifactId>
-                            <version>1.11.1</version>
-                            <exclusions>
-                                <exclusion>
-                                    <artifactId>maven-project</artifactId>
-                                    <groupId>org.apache.maven</groupId>
-                                </exclusion>
-                            </exclusions>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-            </plugins>
-        </build>
+        <project.build.targetJdk>11</project.build.targetJdk>
+        <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
+        <dep.plugin.spotbugs.version>3.1.11</dep.plugin.spotbugs.version>
         <dep.otj-filterorder.version>0.0.5</dep.otj-filterorder.version>
         <dep.otj-httpheaders.version>0.1.2</dep.otj-httpheaders.version>
 
         <!-- Remove when parent is updated -->
         <dep.otj-logging.version>3.0.2</dep.otj-logging.version>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.shared</groupId>
+                        <artifactId>maven-dependency-analyzer</artifactId>
+                        <version>1.11.1</version>
+                        <exclusions>
+                            <exclusion>
+                                <artifactId>maven-project</artifactId>
+                                <groupId>org.apache.maven</groupId>
+                            </exclusion>
+                        </exclusions>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,6 @@
             </dependency>
             <dependency>
                 <groupId>com.opentable.components</groupId>
-                <artifactId>otj-filterorder</artifactId>
-                <version>${dep.otj-filterorder.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.opentable.components</groupId>
                 <artifactId>otj-server-reactive</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,32 @@
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
         <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
 
-        <dep.otj-filterorder.version>0.0.5</dep.otj-filterorder.version>
-    </properties>
+            <project.build.targetJdk>11</project.build.targetJdk>
+            <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
+            <dep.spotbugs.version>3.1.11</dep.spotbugs.version>
+            <dep.plugin.spotbugs.version>3.1.11</dep.plugin.spotbugs.version>
+        </properties>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.shared</groupId>
+                            <artifactId>maven-dependency-analyzer</artifactId>
+                            <version>1.11.1</version>
+                            <exclusions>
+                                <exclusion>
+                                    <artifactId>maven-project</artifactId>
+                                    <groupId>org.apache.maven</groupId>
+                                </exclusion>
+                            </exclusions>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+            </plugins>
+        </build>
 
 
     <scm>
@@ -74,11 +98,6 @@
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-server-mvc</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.opentable.components</groupId>
-                <artifactId>otj-filterorder</artifactId>
-                <version>${dep.otj-filterorder.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Following the same patten used in http server, added a flag which will enable us to disable list of protocols.   For now this flag `-Dot.httpserver.ssl-excluded-protocols=TLSv1.3` has been added to otpl-common-config[Java11 branch]/jvm.properties file.