### PR TITLE
Add support and tests for otj-conservedheaders-reactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 otj-server
 ==========
 
+3.0.11
+-----
+* Supports conserved headers for reactive Spring WebFlux applications (server-side, not for WebClient which will be
+handled as part of the upcoming otj-webclient library). Uses otj-conservedheaders-reactive 3.0.2.
+- Copies conserved headers to the MDC for application and server request logging
+- Copies conserved headers to the outgoing request
+- Creates a request-id if none was provided on incoming headers
+
 3.0.10
 -----
 * Make constructor for otj-sever-reactive's ServerRequestLog public, to support request-id logging for reactive

--- a/otj-server-reactive/pom.xml
+++ b/otj-server-reactive/pom.xml
@@ -26,10 +26,6 @@
     <artifactId>otj-server-reactive</artifactId>
     <description>Provides Spring WebFlux wiring into otj-stack</description>
 
-    <properties>
-
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.opentable.components</groupId>
@@ -49,6 +45,11 @@
         <dependency>
             <groupId>com.opentable.components</groupId>
             <artifactId>otj-metrics-reactive</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-conservedheaders-reactive</artifactId>
         </dependency>
 
         <dependency>
@@ -141,7 +142,11 @@
             <artifactId>jackson-annotations</artifactId>
         </dependency>
 
-        <!-- spring-boot-test uses this but has it optional :/ -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/otj-server-reactive/src/main/java/com/opentable/server/reactive/ReactiveServerCommonConfiguration.java
+++ b/otj-server-reactive/src/main/java/com/opentable/server/reactive/ReactiveServerCommonConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import com.opentable.conservedheaders.reactive.ReactiveServerConservedHeadersConfiguration;
 import com.opentable.metrics.reactive.HealthHttpReactiveConfiguration;
 import com.opentable.metrics.reactive.MetricsHttpReactiveConfiguration;
 import com.opentable.server.EmbeddedJettyConfiguration;
@@ -40,7 +41,10 @@ import com.opentable.server.reactive.webfilter.BackendInfoWebFilterConfiguration
         EmbeddedJettyConfiguration.class,
         EmbeddedReactiveJetty.class,
         // Log server request information
+        // TODO: Remove this after updating servers that use ServerRequestLog directly
         ReactiveServerLoggingConfiguration.class,
+        // Conserved headers
+        ReactiveServerConservedHeadersConfiguration.class,
         // Default health check
         HealthHttpReactiveConfiguration.class,
         // Metrics for http

--- a/otj-server-reactive/src/main/java/com/opentable/server/reactive/logging/ReactiveServerLoggingConfiguration.java
+++ b/otj-server-reactive/src/main/java/com/opentable/server/reactive/logging/ReactiveServerLoggingConfiguration.java
@@ -24,7 +24,7 @@ import com.opentable.logging.jetty.JsonRequestLogConfig;
 /**
  * Configures automatic server request logging using Jetty for reactive applications.
  *
- * @deprecated Reactive services should utiliz the JsonRequestLog that is already imported as part of the
+ * @deprecated Reactive services should utilize the JsonRequestLog that is already imported as part of the
  * EmbeddedJetty server.
  */
 @Deprecated

--- a/otj-server-reactive/src/main/java/com/opentable/server/reactive/logging/ReactiveServerLoggingConfiguration.java
+++ b/otj-server-reactive/src/main/java/com/opentable/server/reactive/logging/ReactiveServerLoggingConfiguration.java
@@ -23,7 +23,11 @@ import com.opentable.logging.jetty.JsonRequestLogConfig;
 
 /**
  * Configures automatic server request logging using Jetty for reactive applications.
+ *
+ * @deprecated Reactive services should utiliz the JsonRequestLog that is already imported as part of the
+ * EmbeddedJetty server.
  */
+@Deprecated
 @Configuration
 public class ReactiveServerLoggingConfiguration {
 

--- a/otj-server-reactive/src/main/java/com/opentable/server/reactive/logging/ServerRequestLog.java
+++ b/otj-server-reactive/src/main/java/com/opentable/server/reactive/logging/ServerRequestLog.java
@@ -25,11 +25,25 @@ import com.opentable.logging.jetty.JsonRequestLogConfig;
 import com.opentable.logging.otl.HttpV1;
 
 /**
+ * NOTE: With the introduction of otj-conservedheaders-reactive, this class is no longer needed, and implementing
+ * reactive servers should now use or extend {@link JsonRequestLog} directly.
+ *
+ * We are leaving this here for the time being as some reactive servers are directly extending this class. It will
+ * be removed in the future once servers are updated to a parent pom version that supports otj-conservedheaders-reactive.
+ *
+ * ------
+ *
  * Logs {@link HttpV1} events for incoming server requests using the underlying Jetty RequestLog.
  *
- * The primary difference between this class and {@link JsonRequestLog} is that this class pulls the OT-RequestId
+ * The *original* difference between this class and {@link JsonRequestLog} is that this class pulls the OT-RequestId
  * header off of the incoming server request, instead of the response.
+ *
+ * EDIT: This behavior has been changed to match the original behavior of {@link JsonRequestLog}, by pulling
+ * the request id from the response.
+ *
+ * @deprecated Users of this class should extend JsonRequestLog directly instead of extending ServerRequestLog.
  */
+@Deprecated
 public class ServerRequestLog extends JsonRequestLog {
 
     public ServerRequestLog(Clock clock, JsonRequestLogConfig config) {
@@ -38,6 +52,6 @@ public class ServerRequestLog extends JsonRequestLog {
 
     @Override
     protected UUID getRequestIdFrom(Request request, Response response) {
-        return optUuid(request.getHeader(OTHeaders.REQUEST_ID));
+        return optUuid(response.getHeader(OTHeaders.REQUEST_ID));
     }
 }

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/BasicTest.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/BasicTest.java
@@ -28,7 +28,7 @@ import com.opentable.logging.CommonLogHolder;
 public class BasicTest extends AbstractTest {
 
     @Autowired
-    WebTestClient webTestClient;
+    private WebTestClient webTestClient;
 
     @Test
     public void applicationLoads() {
@@ -45,6 +45,7 @@ public class BasicTest extends AbstractTest {
         EntityExchangeResult<String> result = webTestClient.get()
                 .uri("/api/test")
                 .exchange()
+                .expectStatus().isOk()
                 .expectBody(String.class)
                 .returnResult();
 

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/ConservedHeadersWebFilterTest.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/ConservedHeadersWebFilterTest.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.server.reactive;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import com.opentable.httpheaders.OTHeaders;
+import com.opentable.logging.otl.HttpV1;
+import com.opentable.server.reactive.utils.ApplicationLogInMemoryAppender;
+import com.opentable.server.reactive.utils.RequestLogInMemoryAppender;
+
+/**
+ * Integration tests for {@link com.opentable.conservedheaders.reactive.ConservedHeadersWebFilter}.
+ * <p>
+ * Verifies the following:
+ * <p>
+ * For an incoming request containing conserved headers:
+ * - Those headers are included on the outgoing response.
+ * - If no request-id header is included, it is added in automatically.
+ * - Log messages associated with the request contain the appropriate conserved header values.
+ * - When reactive operations move between threads (see {@link TestReactiveServerConfiguration} /api/threading)
+ * conserved header information continues to be associated with the request.
+ * - When multiple requests are in-flight simultaneously, conserved header information is associated with the
+ * correct request, even when reactive operations are continued on a thread previously used by a different request.
+ */
+public class ConservedHeadersWebFilterTest extends AbstractTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConservedHeadersWebFilterTest.class);
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    public void testApiCallConservesHeadersOnResponse() {
+        final String requestId = UUID.randomUUID().toString();
+        final String anonId = UUID.randomUUID().toString();
+
+        EntityExchangeResult<String> result = webTestClient.get()
+                .uri("/api/test")
+                .header(OTHeaders.REQUEST_ID, requestId)
+                .header(OTHeaders.ANONYMOUS_ID, anonId)
+                .header("Not-A-Conserved-Header", "some value")
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().valueEquals(OTHeaders.REQUEST_ID, requestId)
+                .expectHeader().valueEquals(OTHeaders.ANONYMOUS_ID, anonId)
+                .expectHeader().doesNotExist("Not-A-Conserved-Header")
+                .expectBody(String.class)
+                .returnResult();
+
+        final String res = result.getResponseBody();
+        assertEquals("test", res);
+    }
+
+    @Test
+    public void testApiCallWithNoRequestIdAddsARequestId() {
+        EntityExchangeResult<String> result = webTestClient.get()
+                .uri("/api/test")
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().exists(OTHeaders.REQUEST_ID)
+                .expectBody(String.class)
+                .returnResult();
+
+        final String res = result.getResponseBody();
+        assertEquals("test", res);
+    }
+
+    /**
+     * This test calls an endpoint on {@link TestReactiveServerConfiguration} a random number of times in parallel
+     * while collecting the application and request logs for all n requests in the two in-memory appenders.
+     * <p>
+     * The API request, /api/threading/{trace}, does the following:
+     * - For the given reactive request, performs a number of reactive operations in a reactive chain.
+     * - For each reactive operation, emits an application log message containing the {trace} parameter that was passed in.
+     * - Occasionally schedules operations in that reactive chain on different threads using a shared scheduler.
+     * <p>
+     * Each request contains a unique request-id and anonymous-id, which should be associated with the
+     * application and request log messages for that request, via the MDC.
+     * <p>
+     * When each parallel request completes, we collect the unique request-id, anonymous-id and trace results
+     * and do the following:
+     * - Filter messages in the appender to only those containing the trace id of the request.
+     * - Verifies that each application message contains the correct request-id and anonymous-id.
+     * - Verifies that each request message contains the correct request-id and anonymous-id.
+     * <p>
+     * Furthermore, the shared scheduler (see {@link TestReactiveServerConfiguration}) contains fewer available
+     * threads than the number of parallel requests invoked in the ForkJoinPool. This forces reactive operations
+     * to be scheduled on threads that were previously used to handle parts of a different request, thus
+     * ensuring that the MDC conserved header values are set correctly even if the thread was re-used.
+     */
+    @Test
+    public void testParallelApiCallsLogConservedHeadersInMDCForCorrectRequest() throws NoSuchFieldException, IllegalAccessException {
+
+        final ApplicationLogInMemoryAppender appLogAppender = ApplicationLogInMemoryAppender.create(TestReactiveServerConfiguration.MyResource.class);
+        final RequestLogInMemoryAppender requestLogAppender = RequestLogInMemoryAppender.create();
+
+        // Create 5-10 random API calls
+        Random r = new Random();
+        int parallelRequests = r.nextInt((10 - 5) + 1) + 5;
+
+        List<TestApiCall> apiCalls = new ArrayList<>(parallelRequests);
+        for (int i = 1; i <= parallelRequests; i++) {
+            TestApiCall apiCall = new TestApiCall(webTestClient, Integer.toString(i),
+                    // Request-id should always be provided, or else it will be auto-generated and then we can't test for it
+                    UUID.randomUUID().toString(),
+                    // Randomly decide to provide the remaining headers or not
+                    randomUUIDorNull(i),
+                    randomUUIDorNull(i)
+            );
+            LOG.info("Created test api call: {}", apiCall);
+            apiCalls.add(apiCall);
+        }
+
+        // Shuffle the list of api calls so we aren't calling it in the same order every time
+        Collections.shuffle(apiCalls);
+
+        final ForkJoinPool forkJoinPool = new ForkJoinPool(parallelRequests);
+        forkJoinPool.invokeAll(apiCalls).forEach(f -> {
+            LoggingTestResult tryResult = null;
+            try {
+                tryResult = f.get();
+            } catch (Exception e) {
+                fail("Got exception: " + e.getMessage());
+            }
+            assertNotNull(tryResult);
+
+            final LoggingTestResult result = tryResult;
+
+            final List<ObjectNode> appLogs = appLogAppender.getEvents().stream()
+                    .filter(e -> e.get("message").textValue().startsWith("(TRACE-" + result.trace + ")"))
+                    .collect(Collectors.toList());
+
+            assertEquals(8, appLogs.size());
+            appLogs.forEach(appLog -> {
+                LOG.info("Got application log with thread-name [{}], request-id [{}], anonymous-id [{}]: {}",
+                        appLog.get("thread-name"), appLog.get("request-id"), appLog.get("anonymous-id"), appLog.get("message"));
+
+                verifyApplicationHeader(result.trace, appLog, "request-id", result.requestId);
+                verifyApplicationHeader(result.trace, appLog, "anonymous-id", result.anonId);
+                verifyApplicationHeader(result.trace, appLog, "session-id", result.sessionId);
+            });
+
+            final List<HttpV1> requestLogs = requestLogAppender.getEvents().stream()
+                    .filter(e -> e.getUrl().equals("/api/threading/" + result.trace))
+                    .collect(Collectors.toList());
+
+            assertEquals(1, requestLogs.size());
+            requestLogs.forEach(e -> {
+                LOG.info("Got request log with request-id [{}], anonymous-id [{}]: {}",
+                        e.getRequestId(), e.getAnonymousId(), e.getUrl());
+
+                assertEquals("request log request-id should match", result.requestId, e.getRequestId().toString());
+                assertEquals("request log anonymous-id should match", result.anonId, e.getAnonymousId());
+                assertEquals("request log session-id should match", result.sessionId, e.getSessionId());
+            });
+
+        });
+    }
+
+    // Random chance of returning a UUID for a header value or null
+    private String randomUUIDorNull(int seed) {
+        Random r = new Random(seed);
+        int i = r.nextInt(100);
+        if (i % 2 != 0) {
+            return UUID.randomUUID().toString();
+        } else {
+            return null;
+        }
+    }
+
+    private void verifyApplicationHeader(String trace, ObjectNode appLog, String headerName, String expectedValue) {
+        JsonNode headerNode = appLog.get(headerName);
+        if (expectedValue != null && headerNode != null) {
+            assertEquals("application log header should match for " + headerName + " with TRACE-" + trace,
+                    expectedValue, headerNode.textValue());
+        } else {
+            assertNull(expectedValue);
+            assertNull("Expected null header for TRACE-" + trace, headerNode);
+        }
+    }
+
+    private static class TestApiCall implements Callable<LoggingTestResult> {
+
+        private final WebTestClient webTestClient;
+        private final String trace;
+        private final String requestId;
+        private final String anonId;
+        private final String sessionId;
+
+        public TestApiCall(WebTestClient webTestClient, String trace,
+                           String requestId,
+                           String anonId,
+                           String sessionId) {
+            this.webTestClient = webTestClient;
+            this.trace = trace;
+            this.requestId = requestId;
+            this.anonId = anonId;
+            this.sessionId = sessionId;
+        }
+
+        @Override
+        public LoggingTestResult call() throws Exception {
+
+            WebTestClient.RequestHeadersSpec spec = webTestClient.get()
+                    .uri("/api/threading/{trace}", trace);
+
+            spec = addHeaderToSpec(OTHeaders.REQUEST_ID, requestId, spec);
+            spec = addHeaderToSpec(OTHeaders.ANONYMOUS_ID, anonId, spec);
+            spec = addHeaderToSpec(OTHeaders.SESSION_ID, sessionId, spec);
+
+            EntityExchangeResult<String> result = spec.exchange()
+                    .expectStatus().isOk()
+                    .expectBody(String.class)
+                    .returnResult();
+
+            final String res = result.getResponseBody();
+            assertEquals("Callable response", res);
+
+            Thread.sleep(2000L);
+
+            return new LoggingTestResult(trace, requestId, anonId, sessionId);
+        }
+
+        private WebTestClient.RequestHeadersSpec addHeaderToSpec(String headerName, String headerValue,
+                                                                 WebTestClient.RequestHeadersSpec spec) {
+            if (headerValue != null) {
+                spec = spec.header(headerName, headerValue);
+            }
+            return spec;
+        }
+
+        @Override
+        public String toString() {
+            return "TestApiCall{" +
+                    "trace='" + trace + '\'' +
+                    ", requestId='" + requestId + '\'' +
+                    ", anonId='" + anonId + '\'' +
+                    ", sessionId='" + sessionId + '\'' +
+                    '}';
+        }
+    }
+
+    private static class LoggingTestResult {
+        final String trace;
+        final String requestId;
+        final String anonId;
+        final String sessionId;
+
+        public LoggingTestResult(String trace, String requestId, String anonId, String sessionId) {
+            this.trace = trace;
+            this.requestId = requestId;
+            this.anonId = anonId;
+            this.sessionId = sessionId;
+        }
+    }
+
+}

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/ServerMetricsTest.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/ServerMetricsTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
-public class TestServerMetrics extends AbstractTest {
+public class ServerMetricsTest extends AbstractTest {
 
     @Autowired private WebTestClient webTestClient;
     @Autowired private MetricRegistry metricRegistry;

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/ServerRequestLoggingTest.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/ServerRequestLoggingTest.java
@@ -16,51 +16,33 @@ package com.opentable.server.reactive;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.lang.reflect.Field;
-import java.util.Stack;
-
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.core.AppenderBase;
-
-import com.opentable.logging.jetty.JsonRequestLog;
-import com.opentable.logging.jetty.RequestLogEvent;
 import com.opentable.logging.otl.HttpV1;
+import com.opentable.server.reactive.utils.RequestLogInMemoryAppender;
 
-public class RequestLoggingTest extends AbstractTest {
+public class ServerRequestLoggingTest extends AbstractTest {
 
     @Autowired private TestRestTemplate testRestTemplate;
 
-    private static final InMemoryAppender APPENDER = new InMemoryAppender();
+    private static RequestLogInMemoryAppender appender;
 
     @Before
     public void setUpLogging() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
-        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
-        APPENDER.setContext(loggerContext);
-        APPENDER.start();
-        Field logField = JsonRequestLog.class.getDeclaredField("LOG");
-        logField.setAccessible(true);
-        Logger requestLogger = (Logger) logField.get(null);
-        requestLogger.addAppender(APPENDER);
-        requestLogger.setLevel(Level.ALL);
-        requestLogger.setAdditive(true);
+        appender = RequestLogInMemoryAppender.create();
     }
 
     @Test
     public void testNormalGet() throws InterruptedException {
         String res = testRestTemplate.getForObject("/api/test", String.class);
         assertEquals("test", res);
+
         Thread.sleep(2000l);
-        RequestLogEvent loggingEvent = (RequestLogEvent) APPENDER.eventStack.pop();
-        HttpV1 payload = loggingEvent.getPayload();
+
+        HttpV1 payload = appender.getEvents().get(appender.getEvents().size() - 1);
         assertEquals(200, payload.getStatus());
         assertEquals("/api/test", payload.getUrl());
         assertEquals(4, payload.getResponseSize());
@@ -71,9 +53,10 @@ public class RequestLoggingTest extends AbstractTest {
     public void testAsyncGet() throws InterruptedException {
         String res = testRestTemplate.getForObject("/api/async", String.class);
         assertEquals("test", res);
+
         Thread.sleep(2000l);
-        RequestLogEvent loggingEvent = (RequestLogEvent) APPENDER.eventStack.pop();
-        HttpV1 payload = loggingEvent.getPayload();
+
+        HttpV1 payload = appender.getEvents().get(appender.getEvents().size() - 1);
         assertEquals(200, payload.getStatus());
         assertEquals("/api/async", payload.getUrl());
         assertEquals(4, payload.getResponseSize());
@@ -83,22 +66,12 @@ public class RequestLoggingTest extends AbstractTest {
     @Test
     public void test404() throws InterruptedException {
         testRestTemplate.getForObject("/this/is/not/a/real/path", String.class);
+
         Thread.sleep(2000l);
-        RequestLogEvent loggingEvent = (RequestLogEvent) APPENDER.eventStack.pop();
-        HttpV1 payload = loggingEvent.getPayload();
+
+        HttpV1 payload = appender.getEvents().get(appender.getEvents().size() - 1);
         assertEquals(404, payload.getStatus());
         assertEquals("/this/is/not/a/real/path", payload.getUrl());
         assertTrue(payload.getDuration() > 0);
-    }
-
-    public static class InMemoryAppender extends AppenderBase<ILoggingEvent> {
-
-        public Stack<ILoggingEvent> eventStack = new Stack<>();
-
-        @Override
-        protected void append(ILoggingEvent eventObject) {
-            eventStack.add(eventObject);
-        }
-
     }
 }

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/TestReactiveServerConfiguration.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/TestReactiveServerConfiguration.java
@@ -18,14 +18,16 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.SpringApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,6 +35,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ResponseStatusException;
 
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
 import com.opentable.service.ServiceInfo;
@@ -41,12 +44,8 @@ import com.opentable.service.ServiceInfo;
 @ReactiveServer
 public class TestReactiveServerConfiguration {
 
-    public static void main(String[] args) {
-        SpringApplication.run(TestReactiveServerConfiguration.class, args);
-    }
-
     @Bean
-    ServiceInfo serviceInfo(@Value("${info.component:test-service}") final String serviceType) {
+    ServiceInfo serviceInfo(@Value("${info.component:service-test}") final String serviceType) {
         return () -> serviceType;
     }
 
@@ -55,15 +54,32 @@ public class TestReactiveServerConfiguration {
         return WebClient.builder().build();
     }
 
+    /**
+     * This scheduler is used by {@link ConservedHeadersWebFilterTest}
+     * to set up fewer available threads than the number of requests we want to make in parallel, to ensure that
+     * reactive operations from different requests are scheduled on threads that were previously used by another
+     * request.
+     */
+    @Bean
+    Scheduler getScheduler() {
+        return Schedulers.newParallel("parallel-scheduler", 3);
+    }
+
     @RestController
     @RequestMapping("/api")
     public static class MyResource {
 
+        private static final Logger LOG = LoggerFactory.getLogger(MyResource.class);
+
         @Autowired
         private WebClient webClient;
 
+        @Autowired
+        private Scheduler parallelScheduler;
+
         @RequestMapping("test")
         public Mono<String> test() {
+            LOG.info("Called 'test' endpoint");
             return Mono.just("test");
         }
 
@@ -91,6 +107,44 @@ public class TestReactiveServerConfiguration {
             return Mono.just("test").delayElement(Duration.ofMillis(500), Schedulers.elastic());
         }
 
+        @GetMapping("threading/{trace}")
+        public Mono<String> getServiceLookup(@PathVariable("trace") String trace) throws Exception {
+
+            LOG.info("(TRACE-{}) Before publisher chain, before sleep", trace);
+
+            Thread.sleep(1000);
+
+            LOG.info("(TRACE-{}) After sleep, before publisher chain", trace);
+
+            return Mono.just("Just some random thing")
+                    .map(c -> {
+                        LOG.error("(TRACE-{}) Inside publisher chain, before error, {}", trace, c);
+                        throw new RuntimeException("Throwing an error");
+                    })
+                    .onErrorResume(d -> {
+                        LOG.error("(TRACE-{}) Inside publisher, after error", trace, d);
+                        return Mono.just("Alternate random thing");
+                    })
+                    .flatMap(e -> {
+                        LOG.info("(TRACE-{}) Inside publisher, before scheduling", trace, e);
+                        return Mono.just(e);
+                    })
+                    .publishOn(parallelScheduler)
+                    .flatMap(f ->
+                    {
+                        LOG.info("(TRACE-{}) After scheduling, inside flatMap, before callable, {}", trace, f);
+                        return Mono.fromCallable(() -> "Callable response")
+                                .flatMap(g -> {
+                                    LOG.info("(TRACE-{}) Inside flatMap, after callable, before scheduling #2, {}", trace, g);
+                                    return Mono.just(g);
+                                })
+                                .publishOn(parallelScheduler)
+                                .flatMap(h -> {
+                                    LOG.info("(TRACE-{}) Inside flatpMap, after scheduling #2, {}", trace, h);
+                                    return Mono.just(h);
+                                });
+                    });
+        }
     }
 
     public static class EchoResponse {

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/utils/ApplicationLogInMemoryAppender.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/utils/ApplicationLogInMemoryAppender.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.server.reactive.utils;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+import com.opentable.logging.JsonLogEncoder;
+
+public class ApplicationLogInMemoryAppender extends AppenderBase<ILoggingEvent> {
+
+    private static final JsonLogEncoder ENCODER = new JsonLogEncoder();
+    private final List<ObjectNode> events = new ArrayList<>();
+
+    public static ApplicationLogInMemoryAppender create(Class klass) throws NoSuchFieldException, IllegalAccessException {
+        ApplicationLogInMemoryAppender applicationLogInMemoryAppender = new ApplicationLogInMemoryAppender();
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        applicationLogInMemoryAppender.setContext(loggerContext);
+        applicationLogInMemoryAppender.start();
+        Field logField = klass.getDeclaredField("LOG");
+        logField.setAccessible(true);
+        Logger applicationLogger = (Logger) logField.get(null);
+        applicationLogger.addAppender(applicationLogInMemoryAppender);
+        applicationLogger.setLevel(Level.ALL);
+        applicationLogger.setAdditive(true);
+
+        return applicationLogInMemoryAppender;
+    }
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        events.add(ENCODER.convertToObjectNode(eventObject));
+    }
+
+    public List<ObjectNode> getEvents() {
+        return events;
+    }
+}

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/utils/RequestLogInMemoryAppender.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/utils/RequestLogInMemoryAppender.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.server.reactive.utils;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+import com.opentable.logging.jetty.JsonRequestLog;
+import com.opentable.logging.jetty.RequestLogEvent;
+import com.opentable.logging.otl.HttpV1;
+
+public class RequestLogInMemoryAppender extends AppenderBase<ILoggingEvent> {
+
+    private final List<HttpV1> events = new ArrayList<>();
+
+    public static RequestLogInMemoryAppender create() throws NoSuchFieldException, IllegalAccessException {
+        RequestLogInMemoryAppender requestLogAppender = new RequestLogInMemoryAppender();
+
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        requestLogAppender.setContext(loggerContext);
+        requestLogAppender.start();
+        Field logField = JsonRequestLog.class.getDeclaredField("LOG");
+        logField.setAccessible(true);
+        Logger requestLogger = (Logger) logField.get(null);
+        requestLogger.addAppender(requestLogAppender);
+        requestLogger.setLevel(Level.ALL);
+        requestLogger.setAdditive(true);
+
+        return requestLogAppender;
+    }
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        events.add(((RequestLogEvent) eventObject).getPayload());
+    }
+
+    public List<HttpV1> getEvents() {
+        return events;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.opentable</groupId>
         <artifactId>otj-parent-spring</artifactId>
-        <version>191</version>
+        <version>196</version>
     </parent>
 
 
@@ -45,8 +45,8 @@
         <dep.otj-filterorder.version>0.0.5</dep.otj-filterorder.version>
         <dep.otj-httpheaders.version>0.1.2</dep.otj-httpheaders.version>
 
-        <!-- Remove when parent is updated -->
-        <dep.otj-logging.version>3.0.2</dep.otj-logging.version>
+        <!-- Remove when otj-parent is updated -->
+        <dep.otj-conservedheaders.version>3.0.2</dep.otj-conservedheaders.version>
     </properties>
 
     <build>
@@ -81,6 +81,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Remove when otj-parent is updated -->
+            <dependency>
+                <groupId>com.opentable.components</groupId>
+                <artifactId>otj-conservedheaders-reactive</artifactId>
+                <version>${dep.otj-conservedheaders.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-server-core</artifactId>


### PR DESCRIPTION
Depends on https://github.com/opentable/otj-conservedheaders/pull/12, which should be merged and otj-conservedheaders-reactive dep should be released and firmed down in this PR.