### PR TITLE
ConservedHeadersJettyErrorHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 otj-server
 ==========
 
+3.0.12
+-----
+* ConservedHeadersJettyErrorHandler preserves conserved headers for unhandled servlet exceptions. 
+
 3.0.11
 -----
 * Supports conserved headers for reactive Spring WebFlux applications (server-side, not for WebClient which will be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ otj-server
 
 3.0.12
 -----
-* ConservedHeadersJettyErrorHandler preserves conserved headers for unhandled servlet exceptions. 
+* ConservedHeadersJettyErrorHandler preserves conserved headers for unhandled servlet exceptions.
+* Jetty default error response for 5xx is modified to disable printing of the full stack trace. It can be explicitly enabled
+by property `ot.httpserver.show-stack-on-error=true`
 
 3.0.11
 -----

--- a/otj-server-core/pom.xml
+++ b/otj-server-core/pom.xml
@@ -106,6 +106,10 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jmx</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.opentable.components</groupId>
+      <artifactId>otj-conservedheaders-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/otj-server-core/src/main/java/com/opentable/server/ConservedHeadersJettyErrorHandler.java
+++ b/otj-server-core/src/main/java/com/opentable/server/ConservedHeadersJettyErrorHandler.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.opentable.server;
 
 import java.io.IOException;
@@ -16,8 +29,18 @@ class ConservedHeadersJettyErrorHandler extends ErrorPageErrorHandler {
 
     private final ErrorHandler delegate;
 
-    ConservedHeadersJettyErrorHandler(ErrorHandler delegate) {
+
+    ConservedHeadersJettyErrorHandler(ErrorHandler delegate, boolean showStacks) {
         this.delegate = delegate;
+        setShowStacks(showStacks);
+    }
+
+    @Override
+    public void setShowStacks(boolean showStacks) {
+        super.setShowStacks(showStacks);
+        if (this.delegate != null) {
+            this.delegate.setShowStacks(showStacks);
+        }
     }
 
     @Override

--- a/otj-server-core/src/main/java/com/opentable/server/ConservedHeadersJettyErrorHandler.java
+++ b/otj-server-core/src/main/java/com/opentable/server/ConservedHeadersJettyErrorHandler.java
@@ -1,0 +1,73 @@
+package com.opentable.server;
+
+import java.io.IOException;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.ErrorHandler;
+import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
+
+import com.opentable.conservedheaders.ConservedHeadersFilter;
+
+class ConservedHeadersJettyErrorHandler extends ErrorPageErrorHandler {
+
+    private final ErrorHandler delegate;
+
+    ConservedHeadersJettyErrorHandler(ErrorHandler delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
+        if (this.delegate != null) {
+            ConservedHeadersFilter.extractHeaders(request)
+                .forEach((header, value) -> response.setHeader(header.getHeaderName(), value));
+            this.delegate.handle(target, baseRequest, request, response);
+        }
+    }
+
+    @Override
+    public void setErrorPages(Map<String, String> errorPages) {
+        super.setErrorPages(errorPages);
+        if (delegate instanceof ErrorPageErrorHandler) {
+            ((ErrorPageErrorHandler)delegate).setErrorPages(errorPages);
+        }
+    }
+
+    @Override
+    public void addErrorPage(Class<? extends Throwable> exception, String uri) {
+        super.addErrorPage(exception, uri);
+        if (delegate instanceof ErrorPageErrorHandler) {
+            ((ErrorPageErrorHandler)delegate).addErrorPage(exception, uri);
+        }
+    }
+
+    @Override
+    public void addErrorPage(String exceptionClassName, String uri) {
+        super.addErrorPage(exceptionClassName, uri);
+        if (delegate instanceof ErrorPageErrorHandler) {
+            ((ErrorPageErrorHandler)delegate).addErrorPage(exceptionClassName, uri);
+        }
+    }
+
+    @Override
+    public void addErrorPage(int code, String uri) {
+        super.addErrorPage(code, uri);
+        if (delegate instanceof ErrorPageErrorHandler) {
+            ((ErrorPageErrorHandler)delegate).addErrorPage(code, uri);
+        }
+    }
+
+    @Override
+    public void addErrorPage(int from, int to, String uri) {
+        super.addErrorPage(from, to, uri);
+        if (delegate instanceof ErrorPageErrorHandler) {
+            ((ErrorPageErrorHandler)delegate).addErrorPage(from, to, uri);
+        }
+    }
+}
+
+

--- a/otj-server-core/src/main/java/com/opentable/server/EmbeddedJetty.java
+++ b/otj-server-core/src/main/java/com/opentable/server/EmbeddedJetty.java
@@ -75,7 +75,7 @@ public class EmbeddedJetty extends EmbeddedJettyBase {
             final PropertyResolver pr,
             final Optional<FilterOrderResolver> filterOrderResolver) {
 
-        final JettyServletWebServerFactory factory = new OTJettyServletWebServerFactory(webAppContextCustomizers);
+        final JettyServletWebServerFactory factory = new OTJettyServletWebServerFactory(webAppContextCustomizers, showStacks);
         JettyWebServerFactoryAdapter factoryAdapter = new JettyWebServerFactoryAdapter(factory);
         this.configureFactoryContainer(requestLogConfig, activeConnectors, pr, factoryAdapter);
 

--- a/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
+++ b/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
@@ -123,6 +123,9 @@ public abstract class EmbeddedJettyBase {
     @Value("${ot.httpserver.sleep-duration-before-shutdown:PT5s}")
     Duration sleepDurationBeforeShutdown;
 
+    @Value("${ot.httpserver.show-stack-on-error:#{environment.acceptsProfiles(\"!deployed\")}}")
+    boolean showStacks;
+
     /**
      * In the case that we bind to port 0, we'll get back a port from the OS.
      * With {@link #containerInitialized(WebServerInitializedEvent)}, we capture this value

--- a/otj-server-core/src/main/java/com/opentable/server/OTJettyServletWebServerFactory.java
+++ b/otj-server-core/src/main/java/com/opentable/server/OTJettyServletWebServerFactory.java
@@ -26,31 +26,36 @@ import org.springframework.boot.web.servlet.ServletContextInitializer;
 public class OTJettyServletWebServerFactory extends JettyServletWebServerFactory {
 
     private final Optional<Collection<Consumer<WebAppContext>>> webAppContextCustomizers;
+    private final boolean showStacks;
 
-    public OTJettyServletWebServerFactory(Optional<Collection<Consumer<WebAppContext>>> webAppContextCustomizers) {
+    public OTJettyServletWebServerFactory(Optional<Collection<Consumer<WebAppContext>>> webAppContextCustomizers, boolean showStacks) {
         this.webAppContextCustomizers = webAppContextCustomizers;
+        this.showStacks = showStacks;
     }
 
     public OTJettyServletWebServerFactory(int port) {
         super(port);
         this.webAppContextCustomizers = Optional.empty();
+        this.showStacks = true;
     }
 
     public OTJettyServletWebServerFactory(String contextPath, int port) {
         super(contextPath, port);
         this.webAppContextCustomizers = Optional.empty();
+        this.showStacks = true;
     }
 
     public OTJettyServletWebServerFactory() {
         super();
         this.webAppContextCustomizers = Optional.empty();
+        this.showStacks = true;
     }
 
     @Override
     protected org.eclipse.jetty.webapp.Configuration[] getWebAppContextConfigurations(WebAppContext webAppContext,
                                                                                       ServletContextInitializer... initializers) {
         webAppContextCustomizers.ifPresent(consumers -> consumers.forEach(c -> c.accept(webAppContext)));
-        webAppContext.setErrorHandler(new ConservedHeadersJettyErrorHandler(webAppContext.getErrorHandler()));
+        webAppContext.setErrorHandler(new ConservedHeadersJettyErrorHandler(webAppContext.getErrorHandler(), showStacks));
         return super.getWebAppContextConfigurations(webAppContext, initializers);
     }
 

--- a/otj-server-core/src/main/java/com/opentable/server/OTJettyServletWebServerFactory.java
+++ b/otj-server-core/src/main/java/com/opentable/server/OTJettyServletWebServerFactory.java
@@ -50,6 +50,7 @@ public class OTJettyServletWebServerFactory extends JettyServletWebServerFactory
     protected org.eclipse.jetty.webapp.Configuration[] getWebAppContextConfigurations(WebAppContext webAppContext,
                                                                                       ServletContextInitializer... initializers) {
         webAppContextCustomizers.ifPresent(consumers -> consumers.forEach(c -> c.accept(webAppContext)));
+        webAppContext.setErrorHandler(new ConservedHeadersJettyErrorHandler(webAppContext.getErrorHandler()));
         return super.getWebAppContextConfigurations(webAppContext, initializers);
     }
 

--- a/otj-server-jaxrs/src/test/java/com/opentable/server/ConservedHeadersTest.java
+++ b/otj-server-jaxrs/src/test/java/com/opentable/server/ConservedHeadersTest.java
@@ -62,6 +62,24 @@ public class ConservedHeadersTest {
     }
 
     @Test
+    public void conserveRequestIdWithFault() {
+        final String rid = UUID.randomUUID().toString();
+        try(final Response resp = request.of("/5xx").request().header(RID, rid).get()){
+            sanityCheck(resp);
+            Assert.assertEquals(rid, resp.getHeaderString(RID));
+        }
+    }
+
+    @Test
+    public void conserveRequestIdWithFault2() {
+        final String rid = UUID.randomUUID().toString();
+        try(final Response resp = request.of("/5xx2").request().header(RID, rid).get()){
+            sanityCheck(resp);
+            Assert.assertEquals(rid, resp.getHeaderString(RID));
+        }
+    }
+
+    @Test
     public void replaceBadRequestId() {
         final String badRid = "not a valid UUID";
         try(final Response resp = request.of("/").request().header(RID, badRid).get()){

--- a/otj-server-jaxrs/src/test/java/com/opentable/server/TestJaxRsServerConfiguration.java
+++ b/otj-server-jaxrs/src/test/java/com/opentable/server/TestJaxRsServerConfiguration.java
@@ -24,6 +24,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.client.Client;
@@ -96,6 +97,13 @@ public class TestJaxRsServerConfiguration {
         public Response get5xx() {
             LOG.info("It is going to happen.");
             throw new RuntimeException("it has happened");
+        }
+
+        @GET()
+        @Path("5xx2")
+        public Response get5xx2() {
+            LOG.info("It is going to happen.");
+            throw new InternalServerErrorException("it has happened");
         }
 
         @GET

--- a/otj-server-mvc/src/test/java/com/opentable/server/ConservedHeadersTest.java
+++ b/otj-server-mvc/src/test/java/com/opentable/server/ConservedHeadersTest.java
@@ -95,6 +95,14 @@ public class ConservedHeadersTest extends AbstractTest {
         assertEquals(requestId, actualRequestId);
     }
 
+    @Test
+    public void conserveRequestIdFault() {
+        final String requestId = UUID.randomUUID().toString();
+        ResponseEntity<String> response = request("/api/fault", REQUEST_ID, requestId);
+        sanityCheck(response);
+        Assert.assertEquals(requestId, response.getHeaders().get(REQUEST_ID).get(0));
+    }
+
     private ResponseEntity<String> request(String url, String header, String value) {
         HttpHeaders headers = new HttpHeaders();
         if (header != null) {


### PR DESCRIPTION
Preserves conserved headers for unhandled servlet exceptions.