### PR TITLE
OTApplication: Do not set `org.springframework.boot.logging.LoggingSystem=none` property on startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 otj-server
 ==========
 
+
+3.0.15
+------
+* OTApplication: Do not set `org.springframework.boot.logging.LoggingSystem=none` property on startup.
+
 3.0.14
 ------
 * Bug fixes on ready check.

--- a/otj-server-core/src/main/java/com/opentable/server/OTApplication.java
+++ b/otj-server-core/src/main/java/com/opentable/server/OTApplication.java
@@ -57,7 +57,6 @@ public final class OTApplication {
      * @return the configured application context
      */
     public static ConfigurableApplicationContext run(Class<?> applicationClass, String[] args, Consumer<SpringApplicationBuilder> customize) {
-        System.setProperty("org.springframework.boot.logging.LoggingSystem", "none");
         final SpringApplicationBuilder builder = new SpringApplicationBuilder(new Class<?>[]{applicationClass});
         builder.main(applicationClass);
         customize.accept(builder);


### PR DESCRIPTION
1) This workaround is not needed any more
2) Escape patch - set system property in config.