### PR TITLE
Install Service Security filters in jaxrs, mvc, and reactive servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 otj-server
 ==========
 
+3.0.18
+------
+* Adds Service Security filters to jaxrs, mvc, and reactive servers (disabled by default)
+
 3.0.17
 ------
 * JettyReactiveWebServerFactory implementation moved to the static class, to avoid Actuator initialization problems.

--- a/otj-server-jaxrs/pom.xml
+++ b/otj-server-jaxrs/pom.xml
@@ -198,6 +198,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-service-security-servlet</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
             <scope>runtime</scope>

--- a/otj-server-jaxrs/src/main/java/com/opentable/server/JAXRSHttpServerCommonConfiguration.java
+++ b/otj-server-jaxrs/src/main/java/com/opentable/server/JAXRSHttpServerCommonConfiguration.java
@@ -28,6 +28,7 @@ import com.opentable.server.jaxrs.ConservedHeadersConfiguration;
 import com.opentable.server.jaxrs.FilterOrderConfiguration;
 import com.opentable.server.jaxrs.JaxRSClientShimConfiguration;
 import com.opentable.server.jaxrs.ResteasyAutoConfiguration;
+import com.opentable.servicesecurity.servlet.ServiceSecurityFilterConfiguration;
 
 /**
  * Common configuration for REST HTTP Server instances
@@ -52,6 +53,8 @@ import com.opentable.server.jaxrs.ResteasyAutoConfiguration;
         MetricsHttpJaxRsConfiguration.class,
         // Conserved Headers
         ConservedHeadersConfiguration.class,
+        // Service Security filter to verify requests
+        ServiceSecurityFilterConfiguration.class,
 })
 @interface JAXRSHttpServerCommonConfiguration {
 }

--- a/otj-server-mvc/pom.xml
+++ b/otj-server-mvc/pom.xml
@@ -116,6 +116,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-service-security-servlet</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId> com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>runtime</scope>

--- a/otj-server-mvc/src/main/java/com/opentable/server/mvc/MVCHttpServerCommonConfiguration.java
+++ b/otj-server-mvc/src/main/java/com/opentable/server/mvc/MVCHttpServerCommonConfiguration.java
@@ -41,6 +41,7 @@ import com.opentable.metrics.mvc.HealthHttpMVCConfiguration;
 import com.opentable.metrics.mvc.MetricsHttpMVCConfiguration;
 import com.opentable.metrics.mvc.ReadyHttpMVCConfiguration;
 import com.opentable.server.ThreadNameFilterConfiguration;
+import com.opentable.servicesecurity.servlet.ServiceSecurityFilterConfiguration;
 
 @Configuration
 @EnableConfigurationProperties
@@ -62,6 +63,8 @@ import com.opentable.server.ThreadNameFilterConfiguration;
         // Logging exception handler
         LoggingHandlerExceptionResolver.class,
         ThreadNameFilterConfiguration.class,
+        // Service Security filter to verify requests
+        ServiceSecurityFilterConfiguration.class,
 })
 class MVCHttpServerCommonConfiguration {
 

--- a/otj-server-reactive/pom.xml
+++ b/otj-server-reactive/pom.xml
@@ -143,6 +143,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.opentable.components</groupId>
+            <artifactId>otj-service-security-reactive</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/otj-server-reactive/src/main/java/com/opentable/server/reactive/ReactiveServerCommonConfiguration.java
+++ b/otj-server-reactive/src/main/java/com/opentable/server/reactive/ReactiveServerCommonConfiguration.java
@@ -30,6 +30,7 @@ import com.opentable.server.EmbeddedJettyConfiguration;
 import com.opentable.server.EmbeddedReactiveJetty;
 import com.opentable.server.NonWebSetup;
 import com.opentable.server.reactive.webfilter.BackendInfoWebFilterConfiguration;
+import com.opentable.servicesecurity.reactive.ServiceSecurityWebFilterConfiguration;
 
 /**
  * Common configuration for Spring WebFlux reactive servers.
@@ -50,6 +51,8 @@ import com.opentable.server.reactive.webfilter.BackendInfoWebFilterConfiguration
         MetricsHttpReactiveConfiguration.class,
         // Filter for transfer of core backend info
         BackendInfoWebFilterConfiguration.class,
+        // Service Security filter to verify requests
+        ServiceSecurityWebFilterConfiguration.class,
 
         // Support static resources
         // TODO: Need to test serving static resources the WebFlux way. See OTPL-3648.

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
 
         <!-- TODO: Remove once parent pom is updated -->
-        <dep.otj-service-security.version>0.1.0</dep.otj-service-security.version>
+        <dep.otj-service-security.version>0.1.1</dep.otj-service-security.version>
         <dep.otj-otl.version>0.9.1</dep.otj-otl.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
 
         <!-- TODO: Remove once parent pom is updated -->
-        <dep.otj-service-security.version>0.0.2-SNAPSHOT</dep.otj-service-security.version>
+        <dep.otj-service-security.version>0.1.0</dep.otj-service-security.version>
         <dep.otj-otl.version>0.9.1</dep.otj-otl.version>
     </properties>
 
@@ -91,13 +91,11 @@
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-service-security-servlet</artifactId>
                 <version>${dep.otj-service-security.version}</version>
-                <scope>compile</scope>
             </dependency>
             <dependency>
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-service-security-reactive</artifactId>
                 <version>${dep.otj-service-security.version}</version>
-                <scope>compile</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
 
         <!-- TODO: Remove once parent pom is updated -->
-        <dep.otj-service-security.version>0.1.1</dep.otj-service-security.version>
+        <dep.otj-service-security.version>1.0.0</dep.otj-service-security.version>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.opentable</groupId>
         <artifactId>otj-parent-spring</artifactId>
-        <version>213</version>
+        <version>216</version>
     </parent>
 
 
@@ -42,6 +42,10 @@
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
         <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
         <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
+
+        <!-- TODO: Remove once parent pom is updated -->
+        <dep.otj-service-security.version>0.0.2-SNAPSHOT</dep.otj-service-security.version>
+        <dep.otj-otl.version>0.9.1</dep.otj-otl.version>
     </properties>
 
 
@@ -80,6 +84,20 @@
                 <groupId>com.opentable.components</groupId>
                 <artifactId>otj-server-reactive</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <!-- TODO: Remove once parent pom is updated -->
+            <dependency>
+                <groupId>com.opentable.components</groupId>
+                <artifactId>otj-service-security-servlet</artifactId>
+                <version>${dep.otj-service-security.version}</version>
+                <scope>compile</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.opentable.components</groupId>
+                <artifactId>otj-service-security-reactive</artifactId>
+                <version>${dep.otj-service-security.version}</version>
+                <scope>compile</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
 
         <!-- TODO: Remove once parent pom is updated -->
         <dep.otj-service-security.version>0.1.1</dep.otj-service-security.version>
-        <dep.otj-otl.version>0.9.1</dep.otj-otl.version>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.opentable</groupId>
         <artifactId>otj-parent-spring</artifactId>
-        <version>216</version>
+        <version>219</version>
     </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
 
         <!-- TODO: Remove once parent pom is updated -->
         <dep.otj-service-security.version>1.0.0</dep.otj-service-security.version>
+        <dep.plugin.pmd.ruleset.version>1.2.6</dep.plugin.pmd.ruleset.version>
     </properties>
 
 


### PR DESCRIPTION
Do not merge, has SNAPSHOT deps for now.

Rollout plan:
In order to roll out the filters, I thought we should add them directly to the servers config in otj-server, and release that in a parent pom update. Backend servers will update the parent pom and the filters will kick in. For case where a server doesn’t have credentials management, app starts up fine and incoming requests simply log that the verification failed (via the new OTL). For case where a server does hava CM but isn’t importing the shared secret, app starts up find and incoming requests simply log that the verification failed. For case where server does have CM and imports the secret, then the verification can pass and logs the identity.

So we can roll this out orthogonally to touching every service under the sun to enable CM and import the secret AND we get the benefit of logging those people who did update to parent pom whatever but don’t have access to the key yet, so we can hound them about it