### PR TITLE
Fix for:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@ otj-server
 
 3.0.17
 ------
-
 * JettyReactiveWebServerFactory implementation moved to the static class, to avoid Actuator initialization problems.
-
 
 3.0.16
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 otj-server
 ==========
 
+3.0.17
+------
+
+* JettyReactiveWebServerFactory implementation moved to the static class, to avoid Actuator initialization problems.
+
+
 3.0.16
 ------
 * Obey HttpBlacklist in ConservedHeadersJettyErrorHandler

--- a/otj-server-core/src/main/java/com/opentable/server/EmbeddedReactiveJetty.java
+++ b/otj-server-core/src/main/java/com/opentable/server/EmbeddedReactiveJetty.java
@@ -47,14 +47,7 @@ public class EmbeddedReactiveJetty extends EmbeddedJettyBase {
     public JettyReactiveWebServerFactory webServerFactory(final JsonRequestLogConfig requestLogConfig,
                                                           final Map<String, ServerConnectorConfig> activeConnectors,
                                                           final PropertyResolver pr) {
-        final JettyReactiveWebServerFactory factory = new JettyReactiveWebServerFactory() {
-            @Override
-            public WebServer getWebServer(HttpHandler httpHandler) {
-                JettyHttpHandlerAdapter servlet = new JettyHttpHandlerAdapter(httpHandler);
-                Server server = createJettyServer(servlet);
-                return new JettyWebServer(server, true);
-            }
-        };
+        final JettyReactiveWebServerFactory factory = new OtJettyReactiveWebServerFactory();
         JettyReactiveWebServerFactoryAdapter factoryAdapter = new JettyReactiveWebServerFactoryAdapter(factory);
         this.configureFactoryContainer(requestLogConfig, activeConnectors, pr, factoryAdapter);
         return factoryAdapter.getFactory();
@@ -105,4 +98,17 @@ public class EmbeddedReactiveJetty extends EmbeddedJettyBase {
         }
     }
 
+    /*
+    Declaring this as a static-inner class to prevent:
+        org.springframework.beans.FatalBeanException: ReactiveWebServerFactory implementation com.opentable.server.EmbeddedReactiveJetty$1 cannot be instantiated.
+        To allow a separate management port to be used, a top-level class or static inner class should be used instead
+    */
+    static class OtJettyReactiveWebServerFactory extends JettyReactiveWebServerFactory {
+        @Override
+        public WebServer getWebServer(HttpHandler httpHandler) {
+            JettyHttpHandlerAdapter servlet = new JettyHttpHandlerAdapter(httpHandler);
+            Server server = createJettyServer(servlet);
+            return new JettyWebServer(server, true);
+        }
+    }
 }


### PR DESCRIPTION
```
org.springframework.beans.FatalBeanException: ReactiveWebServerFactory implementation com.opentable.server.EmbeddedReactiveJetty$1 cannot be instantiated.
To allow a separate management port to be used, a top-level class or static inner class should be used instead

```