### PR TITLE
Fix "X509ExtendedKeyManager only supported on Server" issue

### DIFF
--- a/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
+++ b/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
@@ -419,10 +419,10 @@ public abstract class EmbeddedJettyBase {
         return httpActualPort;
     }
 
-    class SuperSadSslContextFactory extends SslContextFactory {
+    class SuperSadSslContextFactory extends SslContextFactory.Server {
         SuperSadSslContextFactory(String name, ServerConnectorConfig config) {
-            super(config.getKeystore());
             Preconditions.checkState(config.getKeystore() != null, "no keystore specified for '%s'", name);
+            setKeyStorePath(config.getKeystore());
             setKeyStorePassword(config.getKeystorePassword());
         }
 


### PR DESCRIPTION
Fixes exception
```
Caused by: java.lang.UnsupportedOperationException: X509ExtendedKeyManager only supported on Server
```
Details here: https://github.com/eclipse/jetty.project/issues/4425
