### PR TITLE
Only change the method of requests that Jetty won't handle by default

### DIFF
--- a/otj-server-core/src/main/java/com/opentable/server/ConservedHeadersJettyErrorHandler.java
+++ b/otj-server-core/src/main/java/com/opentable/server/ConservedHeadersJettyErrorHandler.java
@@ -14,7 +14,10 @@
 package com.opentable.server;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -31,6 +34,7 @@ class ConservedHeadersJettyErrorHandler extends ErrorPageErrorHandler {
     private static final HeaderBlacklist HEADER_BLACKLIST = HeaderBlacklist.INSTANCE;
     private final ErrorHandler delegate;
 
+    private static final Set<String> HANDLED_HTTP_METHODS = new HashSet<>(Arrays.asList("GET", "POST", "HEAD"));
 
     ConservedHeadersJettyErrorHandler(ErrorHandler delegate, boolean showStacks) {
         this.delegate = delegate;
@@ -54,7 +58,14 @@ class ConservedHeadersJettyErrorHandler extends ErrorPageErrorHandler {
                         response.setHeader(header.getHeaderName(), value);
                     }
                 });
+            final String method = baseRequest.getMethod();
             this.delegate.handle(target, baseRequest, request, response);
+            // WARN: Temporary workaround
+            // https://github.com/spring-projects/spring-boot/commit/323af718e20d2cd3796dd0273e646a674d532260
+            // Should be removed after spring upgrade!!!!!
+            if (HANDLED_HTTP_METHODS.contains(method)) {
+                baseRequest.setMethod(method);
+            }
         }
     }
 

--- a/otj-server-mvc/src/test/java/com/opentable/server/RequestLoggingTest.java
+++ b/otj-server-mvc/src/test/java/com/opentable/server/RequestLoggingTest.java
@@ -88,6 +88,20 @@ public class RequestLoggingTest extends AbstractTest {
         HttpV1 payload = loggingEvent.getPayload();
         assertEquals(404, payload.getStatus());
         assertEquals("/this/is/not/a/real/path", payload.getUrl());
+        assertEquals("GET", payload.getMethod());
+        assertTrue(payload.getResponseSize() > 100);
+        assertTrue(payload.getDuration() > 0);
+    }
+
+    @Test
+    public void test404Post() throws InterruptedException {
+        testRestTemplate.postForObject("/this/is/not/a/real/path", null, String.class);
+        Thread.sleep(2000l);
+        RequestLogEvent loggingEvent = (RequestLogEvent) APPENDER.eventStack.pop();
+        HttpV1 payload = loggingEvent.getPayload();
+        assertEquals(404, payload.getStatus());
+        assertEquals("/this/is/not/a/real/path", payload.getUrl());
+        assertEquals("POST", payload.getMethod());
         assertTrue(payload.getResponseSize() > 100);
         assertTrue(payload.getDuration() > 0);
     }


### PR DESCRIPTION
This commit workarounds JettyEmbeddedErrorHandler to only set the method on a request for which error handling is being performed if the method isn't already one that will be handled, leaving the method of GET, POST, and HEAD requests unchanged.