### PR TITLE
expose cipher exclusion flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 otj-server
 ==========
 
+5.2.3
+=====
+* update to parent pom 264
+* deleted SuperSadSslFactory
+* introduced ot.httpserver.ssl-excluded-cipher-suits flag
+
 5.2.2
 =====
 * Jetty low resource monitor. 

--- a/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
+++ b/otj-server-core/src/main/java/com/opentable/server/EmbeddedJettyBase.java
@@ -283,7 +283,7 @@ public abstract class EmbeddedJettyBase {
             }
 
             if (!CollectionUtils.isEmpty(excludedCipherSuits)) {
-                LOG.warn("Excluding following cipher suits:");
+                LOG.warn("Excluding following cipher suites:");
                 excludedCipherSuits.forEach(cipher -> LOG.warn("Disabling {}", cipher));
                 ssl.setExcludeCipherSuites(excludedCipherSuits.toArray(new String[0]));
             }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.opentable</groupId>
         <artifactId>otj-parent-spring</artifactId>
-        <version>261</version>
+        <version>264</version>
     </parent>
 
 


### PR DESCRIPTION
changes:

- update to parent pom 264
- deleted SuperSadSslFactory
- introduced `ot.httpserver.ssl-excluded-cipher-suits` flag