### PR TITLE
PAtch to make compatibile with conserved header change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
 otj-server
 ==========
 
-5.2.6
+5.2.5
 -----
 * Fixes to work with new otj-conservedheader changes for overriding headers
 * Tests for overriding and conserving headers.
-
-5.2.5
------
 * POM 271
 * Add Dmitry's test to verify HTTP POST with 404 reacts correctly.
 * Patch an issue in conserved headers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 otj-server
 ==========
-
-Future
+5.2.5
 -----
 * POM 271
 * Add Dmitry's test to verify HTTP POST with 404 reacts correctly.
+* Patch an issue in conserved headers.
 
 5.2.4
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 otj-server
 ==========
+
+5.2.6
+-----
+* Fixes to work with new otj-conservedheader changes for overriding headers
+* Tests for overriding and conserving headers.
+
 5.2.5
 -----
 * POM 271

--- a/otj-server-core/src/main/java/com/opentable/server/ConservedHeadersJettyErrorHandler.java
+++ b/otj-server-core/src/main/java/com/opentable/server/ConservedHeadersJettyErrorHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.ErrorPageErrorHandler;
 
+import com.opentable.conservedheaders.ConservedHeaderOverrideProvider;
 import com.opentable.conservedheaders.ConservedHeadersFilter;
 import com.opentable.httpheaders.HeaderBlacklist;
 
@@ -48,7 +49,7 @@ class ConservedHeadersJettyErrorHandler extends ErrorPageErrorHandler {
     @Override
     public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
         if (this.delegate != null) {
-            ConservedHeadersFilter.extractHeaders(request)
+            ConservedHeadersFilter.extractHeaders(request, ConservedHeaderOverrideProvider.none())
                 .forEach((header, value) -> {
                     if (HEADER_BLACKLIST.canCopyToResponse(header.getHeaderName())) {
                         response.setHeader(header.getHeaderName(), value);

--- a/otj-server-jaxrs/src/test/java/com/opentable/server/ConservedHeadersTest.java
+++ b/otj-server-jaxrs/src/test/java/com/opentable/server/ConservedHeadersTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -38,6 +39,7 @@ import com.opentable.conservedheaders.ConservedHeader;
 public class ConservedHeadersTest {
     private final static String RID = ConservedHeader.REQUEST_ID.getHeaderName();
     private final static String AID = ConservedHeader.ANONYMOUS_ID.getHeaderName();
+    private static final String CLAIMS_ID = ConservedHeader.CLAIMS_ID.getHeaderName();
 
     @Inject
     JAXRSLoopbackRequest request;
@@ -61,6 +63,14 @@ public class ConservedHeadersTest {
             sanityCheck(resp);
             Assert.assertEquals(rid, resp.getHeaderString(RID));
         }
+    }
+
+    // Conserved if supplied
+    @Test
+    public void conserveOtClaims() {
+        final String claimsId = UUID.randomUUID().toString();
+        String response = request.of("/conservedclaims").request().header(CLAIMS_ID, claimsId).get(String.class);
+        Assert.assertEquals(claimsId, response);
     }
 
     @Test

--- a/otj-server-jaxrs/src/test/java/com/opentable/server/OverrideConfiguration.java
+++ b/otj-server-jaxrs/src/test/java/com/opentable/server/OverrideConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.server;
+
+import java.util.Locale;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import com.opentable.conservedheaders.ConservedHeader;
+import com.opentable.conservedheaders.ConservedHeaderValueOverrider;
+import com.opentable.conservedheaders.EnvironmentConservedHeaderOverrideProvider;
+
+@Configuration
+public class OverrideConfiguration {
+    @Bean
+    public ConservedHeaderValueOverrider foo(Environment environment) {
+        return new EnvironmentConservedHeaderOverrideProvider(environment,
+                ConservedHeader.CLAIMS_ID.getHeaderName(), ConservedHeader.CLAIMS_ID);
+    }
+}

--- a/otj-server-jaxrs/src/test/java/com/opentable/server/OverrideConservedHeadersTest.java
+++ b/otj-server-jaxrs/src/test/java/com/opentable/server/OverrideConservedHeadersTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.server;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.UUID;
+
+import javax.inject.Inject;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.opentable.conservedheaders.ConservedHeader;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {TestJaxRsServerConfiguration.class, OverrideConfiguration.class
+}, webEnvironment = RANDOM_PORT)
+@ActiveProfiles(profiles = "test")
+@TestPropertySource(properties = {
+        "info.component=test",
+        "ot.httpserver.active-connectors=boot",
+        "OT-Claims=foo",
+})
+@DirtiesContext
+public class OverrideConservedHeadersTest {
+
+    private static final String CLAIMS_ID = ConservedHeader.CLAIMS_ID.getHeaderName();
+
+    @Inject
+    JAXRSLoopbackRequest request;
+
+    // Conserved if supplied
+    @Test
+    public void conserveOtClaims() {
+        final String claimsId = UUID.randomUUID().toString();
+        String response = request.of("/conservedclaims")
+        .request()
+                .header(CLAIMS_ID, claimsId).get(String.class);
+        Assert.assertEquals("foo", response);
+    }
+
+}

--- a/otj-server-jaxrs/src/test/java/com/opentable/server/TestJaxRsServerConfiguration.java
+++ b/otj-server-jaxrs/src/test/java/com/opentable/server/TestJaxRsServerConfiguration.java
@@ -36,11 +36,13 @@ import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.webapp.WebAppContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
+import com.opentable.conservedheaders.ConservedHeader;
 import com.opentable.jaxrs.JaxRsClientFactory;
 import com.opentable.jaxrs.StandardFeatureGroup;
 import com.opentable.service.ServiceInfo;
@@ -104,6 +106,12 @@ public class TestJaxRsServerConfiguration {
         public Response get5xx2() {
             LOG.info("It is going to happen.");
             throw new InternalServerErrorException("it has happened");
+        }
+
+        @GET
+        @Path("conservedclaims")
+        public String conserved() {
+            return MDC.get(ConservedHeader.CLAIMS_ID.getLogName());
         }
 
         @GET

--- a/otj-server-mvc/src/test/java/com/opentable/server/ConservedHeadersTest.java
+++ b/otj-server-mvc/src/test/java/com/opentable/server/ConservedHeadersTest.java
@@ -33,6 +33,7 @@ import com.opentable.server.TestMvcServerConfiguration.EchoResponse;
 public class ConservedHeadersTest extends AbstractTest {
 
     private static final String REQUEST_ID = ConservedHeader.REQUEST_ID.getHeaderName();
+    private static final String CLAIMS_ID = ConservedHeader.CLAIMS_ID.getHeaderName();
     private static final String ANONYMOUS_ID = ConservedHeader.ANONYMOUS_ID.getHeaderName();
 
     @Autowired
@@ -57,6 +58,14 @@ public class ConservedHeadersTest extends AbstractTest {
         ResponseEntity<String> response = request("/api/test", REQUEST_ID, requestId);
         sanityCheck(response);
         Assert.assertEquals(requestId, response.getHeaders().get(REQUEST_ID).get(0));
+    }
+
+    // Conserved if supplied
+    @Test
+    public void conserveOtClaims() {
+        final String claimsId = UUID.randomUUID().toString();
+        ResponseEntity<String> response = request("/api/conservedclaims", CLAIMS_ID, claimsId);
+        Assert.assertEquals(claimsId, response.getBody());
     }
 
     // Conserved in async

--- a/otj-server-mvc/src/test/java/com/opentable/server/OverrideConfiguration.java
+++ b/otj-server-mvc/src/test/java/com/opentable/server/OverrideConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.server;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import com.opentable.conservedheaders.ConservedHeader;
+import com.opentable.conservedheaders.ConservedHeaderValueOverrider;
+import com.opentable.conservedheaders.EnvironmentConservedHeaderOverrideProvider;
+
+@Configuration
+public class OverrideConfiguration {
+    @Bean
+    public ConservedHeaderValueOverrider foo(Environment environment) {
+        return new EnvironmentConservedHeaderOverrideProvider(environment,
+                ConservedHeader.CLAIMS_ID.getHeaderName(), ConservedHeader.CLAIMS_ID);
+    }
+}

--- a/otj-server-mvc/src/test/java/com/opentable/server/OverrideConservedHeadersTest.java
+++ b/otj-server-mvc/src/test/java/com/opentable/server/OverrideConservedHeadersTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.server;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.UUID;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.opentable.conservedheaders.ConservedHeader;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {TestMvcServerConfiguration.class, OverrideConfiguration.class
+}, webEnvironment = RANDOM_PORT)
+@ActiveProfiles(profiles = "test")
+@TestPropertySource(properties = {
+        "info.component=test",
+        "ot.httpserver.active-connectors=boot",
+        "OT-Claims=foo",
+})
+@DirtiesContext
+public class OverrideConservedHeadersTest {
+
+    HttpServerInfo httpServerInfo;
+
+    @Value("${local.server.port}")
+    int port;
+
+    @Inject
+    public void init(Provider<HttpServerInfo> info) {
+        this.httpServerInfo = info.get();
+    }
+
+    private static final String CLAIMS_ID = ConservedHeader.CLAIMS_ID.getHeaderName();
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+
+    // Conserved if supplied
+    @Test
+    public void conserveOtClaims() {
+        final String claimsId = UUID.randomUUID().toString();
+        ResponseEntity<String> response = request("/api/conservedclaims", CLAIMS_ID, claimsId);
+        Assert.assertEquals("foo", response.getBody());
+    }
+
+    private ResponseEntity<String> request(String url, String header, String value) {
+        HttpHeaders headers = new HttpHeaders();
+        if (header != null) {
+            headers.add(header, value);
+        }
+        return testRestTemplate.exchange(url,
+            HttpMethod.GET,
+            new HttpEntity<>(null, headers),
+            String.class);
+
+    }
+}

--- a/otj-server-mvc/src/test/java/com/opentable/server/TestMvcServerConfiguration.java
+++ b/otj-server-mvc/src/test/java/com/opentable/server/TestMvcServerConfiguration.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -52,6 +53,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.request.async.DeferredResult;
 import org.springframework.web.server.ResponseStatusException;
 
+import com.opentable.conservedheaders.ConservedHeader;
 import com.opentable.server.mvc.MVCServer;
 import com.opentable.service.ServiceInfo;
 
@@ -111,6 +113,10 @@ public class TestMvcServerConfiguration {
         }
 
 
+        @GetMapping("conservedclaims")
+        public ResponseEntity<String> conserved() {
+            return ResponseEntity.ok(MDC.get(ConservedHeader.CLAIMS_ID.getLogName()));
+        }
         @GetMapping("/nuclear-launch-codes")
         @RolesAllowed("POTUS") // This annotation doesn't work without spring security
         public ResponseEntity<String> getLaunchCode(HttpServletRequest request) {

--- a/otj-server-reactive/pom.xml
+++ b/otj-server-reactive/pom.xml
@@ -54,6 +54,12 @@
 
         <dependency>
             <groupId>com.opentable.components</groupId>
+            <artifactId>otj-conservedheaders-core</artifactId>
+        </dependency>
+
+
+        <dependency>
+            <groupId>com.opentable.components</groupId>
             <artifactId>otj-logging</artifactId>
         </dependency>
 

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/ConservedHeadersWebFilterTest.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/ConservedHeadersWebFilterTest.java
@@ -68,11 +68,13 @@ public class ConservedHeadersWebFilterTest extends AbstractTest {
     public void testApiCallConservesHeadersOnResponse() {
         final String requestId = UUID.randomUUID().toString();
         final String anonId = UUID.randomUUID().toString();
+        final String claimId = UUID.randomUUID().toString();
 
         EntityExchangeResult<String> result = webTestClient.get()
-                .uri("/api/test")
+                .uri("/api/conservedclaims")
                 .header(OTHeaders.REQUEST_ID, requestId)
                 .header(OTHeaders.ANONYMOUS_ID, anonId)
+                .header(OTHeaders.CLAIMS_ID, claimId)
                 .header("Not-A-Conserved-Header", "some value")
                 .exchange()
                 .expectStatus().isOk()
@@ -82,8 +84,9 @@ public class ConservedHeadersWebFilterTest extends AbstractTest {
                 .expectBody(String.class)
                 .returnResult();
 
+
         final String res = result.getResponseBody();
-        assertEquals("test", res);
+        assertEquals(claimId, res);
     }
 
     @Test

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/OverrideConfiguration.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/OverrideConfiguration.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.server.reactive;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import com.opentable.conservedheaders.ConservedHeader;
+import com.opentable.conservedheaders.ConservedHeaderValueOverrider;
+import com.opentable.conservedheaders.EnvironmentConservedHeaderOverrideProvider;
+
+@Configuration
+public class OverrideConfiguration {
+    @Bean
+    public ConservedHeaderValueOverrider foo(Environment environment) {
+        return new EnvironmentConservedHeaderOverrideProvider(environment,
+                ConservedHeader.CLAIMS_ID.getHeaderName(), ConservedHeader.CLAIMS_ID);
+    }
+}

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/OverrideConservedHeadersTest.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/OverrideConservedHeadersTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.opentable.server.reactive;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.UUID;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import com.opentable.httpheaders.OTHeaders;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {TestReactiveServerConfiguration.class, OverrideConfiguration.class}, webEnvironment = RANDOM_PORT)
+@ActiveProfiles(profiles = "test")
+@TestPropertySource(properties = {
+        "info.component=test",
+        "OT-Claims=foo"
+})
+@DirtiesContext
+public class OverrideConservedHeadersTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    public void testApiCallConservesHeadersButOverridesAsNeeded() {
+        final String requestId = UUID.randomUUID().toString();
+        final String anonId = UUID.randomUUID().toString();
+        final String claimId = UUID.randomUUID().toString();
+
+        EntityExchangeResult<String> result = webTestClient.get()
+                .uri("/api/conservedclaims")
+                .header(OTHeaders.REQUEST_ID, requestId)
+                .header(OTHeaders.ANONYMOUS_ID, anonId)
+                .header(OTHeaders.CLAIMS_ID, claimId)
+                .header("Not-A-Conserved-Header", "some value")
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().valueEquals(OTHeaders.REQUEST_ID, requestId)
+                .expectHeader().valueEquals(OTHeaders.ANONYMOUS_ID, anonId)
+                .expectHeader().doesNotExist("Not-A-Conserved-Header")
+                .expectBody(String.class)
+                .returnResult();
+
+
+        final String res = result.getResponseBody();
+        assertEquals("foo", res);
+    }
+
+}

--- a/otj-server-reactive/src/test/java/com/opentable/server/reactive/TestReactiveServerConfiguration.java
+++ b/otj-server-reactive/src/test/java/com/opentable/server/reactive/TestReactiveServerConfiguration.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +40,7 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
+import com.opentable.conservedheaders.ConservedHeader;
 import com.opentable.service.ServiceInfo;
 
 @Configuration
@@ -83,6 +85,12 @@ public class TestReactiveServerConfiguration {
         public Mono<String> test() {
             LOG.info("Called 'test' endpoint");
             return Mono.just("test");
+        }
+
+        @RequestMapping("conservedclaims")
+        public Mono<String> cl() {
+            LOG.info("Called 'test' endpoint");
+            return Mono.just(MDC.get(ConservedHeader.CLAIMS_ID.getHeaderName()));
         }
 
         @GetMapping("echo")

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
         <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
         <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
+        <dep.otj-conservedheaders.version>5.2.1-SNAPSHOT</dep.otj-conservedheaders.version>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,14 +36,13 @@
     </organization>
 
     <properties>
-        <!-- remove once parent updated -->
-        <dep.otj-logging.version>5.2.2</dep.otj-logging.version>
 
         <basepom.oss.skip-scala-doc>true</basepom.oss.skip-scala-doc>
         <basepom.check.skip-javadoc>false</basepom.check.skip-javadoc>
         <basepom.check.fail-javadoc>false</basepom.check.fail-javadoc>
         <basepom.check.fail-spotbugs>false</basepom.check.fail-spotbugs>
-        <dep.otj-conservedheaders.version>5.2.1-SNAPSHOT</dep.otj-conservedheaders.version>
+        <!-- Remove once parent updated -->
+        <dep.otj-conservedheaders.version>5.2.1</dep.otj-conservedheaders.version>
     </properties>
 
 


### PR DESCRIPTION
Basicallly with the changes to otj-conservedheader, a signature changed in some common code.